### PR TITLE
httpflow相关的Metric中添加traceID、spanID相关的Tag

### DIFF
--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -530,9 +530,9 @@ func openPprof(host, port string) {
 
 func initLogger(log **logger.Logger, name, path, level string) error {
 	logOpt := logger.Option{
-		//Path:  path,
+		Path:  path,
 		Level: level,
-		Flags: logger.OPT_DEFAULT | logger.OPT_STDOUT,
+		Flags: logger.OPT_DEFAULT,
 	}
 
 	if err := logger.InitRoot(&logOpt); err != nil {

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -530,9 +530,9 @@ func openPprof(host, port string) {
 
 func initLogger(log **logger.Logger, name, path, level string) error {
 	logOpt := logger.Option{
-		Path:  path,
+		//Path:  path,
 		Level: level,
-		Flags: logger.OPT_DEFAULT,
+		Flags: logger.OPT_DEFAULT | logger.OPT_STDOUT,
 	}
 
 	if err := logger.InitRoot(&logOpt); err != nil {

--- a/internal/l7flow/protodec/agg.go
+++ b/internal/l7flow/protodec/agg.go
@@ -93,6 +93,16 @@ func (agg *HTTPAggP) Obs(conn *comm.ConnectionInfo, data *ProtoData) {
 	// direction
 	key.direction = data.Direction.String()
 
+	// traceID
+	if !data.Meta.TraceID.Zero() {
+		key.TraceID = data.Meta.TraceID.StringHex()
+	}
+
+	// SpanID
+	if !data.Meta.ParentSpanID.Zero() {
+		key.SpanID = data.Meta.ParentSpanID.StringHex()
+	}
+
 	// family
 	isV6 := !netflow.ConnAddrIsIPv4(conn.Meta)
 	if conn.Saddr[0] == 0 && conn.Saddr[1] == 0 &&
@@ -220,6 +230,14 @@ func kv2point(key *aggKey, value *aggValue, pTime time.Time,
 		"dst_ip_type": key.dType,
 
 		"netns": key.NetNS,
+	}
+
+	if key.TraceID != "" {
+		tags["trace_id"] = key.TraceID
+	}
+
+	if key.SpanID != "" {
+		tags["span_id"] = key.SpanID
 	}
 
 	if key.DNATAddr != "" && key.DNATPort != 0 {

--- a/internal/netflow/agg.go
+++ b/internal/netflow/agg.go
@@ -25,6 +25,9 @@ type BaseKey struct {
 	DNATPort uint32
 
 	NetNS string
+
+	TraceID string
+	SpanID  string
 }
 
 type aggKey struct {


### PR DESCRIPTION
在httpflow L7层的采集中，如果http header中解析出了trace相关信息，可以放到生成的数据中，这样出来的数据就可以和trace进行关联分析